### PR TITLE
Add interface for template engine

### DIFF
--- a/classes/class-bb-twitterfeed.php
+++ b/classes/class-bb-twitterfeed.php
@@ -2,8 +2,6 @@
 
 namespace Twitterfeed;
 
-use Mustache_Engine;
-use Mustache_Loader_FilesystemLoader;
 use Wp_Twitter_Api;
 
 /**
@@ -19,7 +17,7 @@ class Twitterfeed {
 	private $profile_image_size;
 
 	private $twitter_error;
-	private $mustache;
+	private $template_engine;
 	private $settings;
 
 	/**
@@ -42,17 +40,16 @@ class Twitterfeed {
 	public function __construct() {
 		$this->number_of_tweets = 5;
 		$this->profile_image_size = 'normal';
-
-		$this->mustache = new Mustache_Engine( [
-			'loader' => new Mustache_Loader_FilesystemLoader( BBTF_PATH . '/views' ),
-			'partials_loader' => new Mustache_Loader_FilesystemLoader( BBTF_PATH . '/views/partials' ),
+		$this->template_engine = new Mustache_Template_Engine( [
+			'main' => '/views',
+			'partials' => '/views/partials'
 		] );
 
 		new I18n();
 		$this->shortcode = new Shortcode( $this );
-		$this->twitter_error = new Twitter_Error( $this->mustache );
+		$this->twitter_error = new Twitter_Error( $this->template_engine );
 
-		$this->settings = new Settings( new Settings_Page, $this->mustache );
+		$this->settings = new Settings( new Settings_Page, $this->template_engine );
 		$this->settings->init();
 	}
 
@@ -134,7 +131,7 @@ class Twitterfeed {
 	 * @return string
 	 */
 	private function get_list( Tweets $tweets ) {
-		return $this->mustache->render( 'tweets', $tweets );
+		return $this->template_engine->render( 'tweets', $tweets );
 	}
 
 	/**

--- a/classes/class-mustache-template-engine.php
+++ b/classes/class-mustache-template-engine.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Twitterfeed;
+
+use Mustache_Engine;
+use Mustache_Loader_FilesystemLoader;
+
+class Mustache_Template_Engine implements Template_Engine {
+
+	private $template_engine;
+
+    public function __construct( $views ) {
+		$this->template_engine = new Mustache_Engine( [
+			'loader' => new Mustache_Loader_FilesystemLoader( BBTF_PATH . $views['main'] ),
+			'partials_loader' => new Mustache_Loader_FilesystemLoader( BBTF_PATH . $views['partials'] ),
+		] );
+    }
+
+    public function render( $view, $view_context ) {
+		return $this->template_engine->render( $view, $view_context );
+    }
+
+}

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -2,9 +2,6 @@
 
 namespace Twitterfeed;
 
-use Mustache_Engine;
-use Mustache_Loader_FilesystemLoader;
-
 /**
  * Handles settings and creates a WordPress dashboard settings page where user
  * can enter Twitter API key and secret.
@@ -12,17 +9,17 @@ use Mustache_Loader_FilesystemLoader;
 class Settings {
 
     private $settings_page;
-	private $mustache;
+	private $template_engine;
 
 	/*
 	 * Creates a Settings object with a WordPress Admin settings page.
 	 *
 	 * @param Settings_Page $settings_page
-	 * @param Mustache_Engine $mustache
+	 * @param Template_Engine $template
 	 */
-	public function __construct( Settings_Page $settings_page, Mustache_Engine $mustache ) {
+	public function __construct( Settings_Page $settings_page, Template_Engine $template_engine ) {
 		$this->settings_page = $settings_page;
-		$this->mustache = $mustache;
+		$this->template_engine = $template_engine;
 	}
 
 	/**
@@ -47,15 +44,6 @@ class Settings {
 	}
 
 	/**
-	 * Renders the contents of the page associated with the settings that
-	 * invokes the render method. In the context of this plugin, this is the
-	 * Settings_Page class.
-	 */
-	public function render() {
-		echo $this->mustache->render( 'settings', $this->settings_page );
-	}
-
-	/**
 	 * Returns Twitter API credentials.
 	 *
 	 * @return array
@@ -65,6 +53,15 @@ class Settings {
 			'consumer_key'    => get_option( 'twitterfeed-key' ),
 			'consumer_secret' => get_option( 'twitterfeed-secret' )
 		];
+	}
+
+	/**
+	 * Renders the contents of the page associated with the settings that
+	 * invokes the render method. In the context of this plugin, this is the
+	 * Settings_Page class.
+	 */
+	public function render() {
+		echo $this->template_engine->render( 'settings', $this->settings_page );
 	}
 
 }

--- a/classes/class-twitter-error.php
+++ b/classes/class-twitter-error.php
@@ -3,8 +3,6 @@
 namespace Twitterfeed;
 
 use WP_Error;
-use Mustache_Engine;
-use Mustache_Loader_FilesystemLoader;
 
 /**
  * Wrapper around the WP_Error class.
@@ -14,7 +12,7 @@ class Twitter_Error {
 	public $errors;
 	public $error_messages;
 	public $heading;
-	private $mustache;
+	private $tempate_engine;
 
 	/**
 	 * Creates an instance of Twitter_Error and assigns a Mustache template for
@@ -22,9 +20,9 @@ class Twitter_Error {
 	 *
 	 * @param Mustache_Engine $mustache
 	 */
-	public function __construct( Mustache_Engine $mustache ) {
+	public function __construct( Template_Engine $template_engine ) {
 		$this->errors = new WP_Error;
-		$this->mustache = $mustache;
+		$this->template_engine = $template_engine;
 		$this->heading = __( 'Oops, something went wrong. Please rectify these errors.', 'bb-twitterfeed' );
 	}
 
@@ -45,7 +43,7 @@ class Twitter_Error {
 		$this->error_messages = $this->errors->get_error_messages();
 
 		if ( !empty ( $this->error_messages ) ) {
-			echo $this->mustache->render( 'errors', $this );
+			echo $this->template_engine->render( 'errors', $this );
 		}
 	}
 }

--- a/classes/interface-template-engine.php
+++ b/classes/interface-template-engine.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Twitterfeed;
+
+Interface Template_Engine {
+
+    /**
+     * Renders the view.
+     *
+     * @param String $view View that we'll render.
+     * @param Object $view_context View object that we'll render within the view.
+     * @return String
+     */
+    public function render( $view, $view_context );
+
+}


### PR DESCRIPTION
To decouple mustache engine from classes that we render views. By using
an interface we can easily swap template engines at a later stage.